### PR TITLE
Fix water extent endpoint and add test

### DIFF
--- a/django_project/project/tests/utils/test_pollution.py
+++ b/django_project/project/tests/utils/test_pollution.py
@@ -1,7 +1,7 @@
 import os
 import json
 from django.test import TestCase
-from django_project.core.settings.utils import absolute_path
+from core.settings.utils import absolute_path
 from project.utils.calculations.pollution import PollutionAnalyzer
 
 TEST_DATA_PATH = absolute_path('project', 'tests', 'data')


### PR DESCRIPTION
This is PR for #83 
I checked the implementation and it seems that the endpoint relies on having AWEI output (non clipped) generated as pre-condition. What I did is creating awei output if no awei output exists for the specified parameter. 

![image](https://github.com/user-attachments/assets/d0b44ecf-2d16-44a5-919c-1ccdeedfc78f)
