### PR TITLE
Fix/queue retry

### DIFF
--- a/django_project/project/admin/monitor.py
+++ b/django_project/project/admin/monitor.py
@@ -57,7 +57,7 @@ class TaskOutputInline(admin.TabularInline):
 class AnalysisTaskAdmin(admin.ModelAdmin):
     list_display = ('task_name', 'status', 'created_by', 'created_at', 'started_at', 'completed_at')
     list_filter = ('status', 'created_at', 'started_at', 'completed_at')
-    search_fields = ('task_name', 'created_by__username', 'uuid')
+    search_fields = ('task_name', 'created_by__username', 'uuid', 'celery_task_id')
     readonly_fields = ('uuid', 'started_at', 'created_at', 'completed_at')
     inlines = [TaskOutputInline]
     ordering = ('-created_at', )

--- a/django_project/project/models/monitor.py
+++ b/django_project/project/models/monitor.py
@@ -329,4 +329,7 @@ class CrawlProgress(models.Model):
     def save(self, *args, **kwargs):
         if self.data_to_process > 0:
             self.progress = int(self.processed_data / self.data_to_process) * 100
+            if self.progress >= 100:
+                self.status = Status.COMPLETED
+                self.completed_at = timezone.now()
         super().save(*args, **kwargs)

--- a/django_project/project/models/monitor.py
+++ b/django_project/project/models/monitor.py
@@ -127,7 +127,7 @@ class AnalysisTask(models.Model):
         self.save()
 
     def failed(self):
-        self.status = self.Status.FAILED
+        self.status = Status.FAILED
         self.completed_at = timezone.now()
         self.save()
 

--- a/django_project/project/tasks/analysis.py
+++ b/django_project/project/tasks/analysis.py
@@ -27,7 +27,7 @@ def run_analysis(start_date,
         task = AnalysisTask.objects.get(uuid=task_id)
     except AnalysisTask.DoesNotExist:
         logger.error(f"Task with id {task_id} does not exist.")
-        return
+        return False
 
     task.start()
     try:
@@ -49,8 +49,10 @@ def run_analysis(start_date,
     except Exception as e:
         task.add_log(str(e), logging.ERROR)
         task.failed()
+        return False
     else:
         task.complete()
+        return True
 
 
 @app.task(bind=True, name='run_analysis_task')
@@ -75,7 +77,7 @@ def run_analysis_task(self,
         task = AnalysisTask.objects.get(uuid=task_id)
     except AnalysisTask.DoesNotExist:
         logger.error(f"Task with id {task_id} does not exist.")
-        return
+        return False
 
     task.start()
     try:
@@ -98,6 +100,8 @@ def run_analysis_task(self,
         task.add_log(str(e), logging.ERROR)
         task.failed()
         self.update_state(state="FAILURE")
+        return False
     else:
         task.complete()
         self.update_state(state="SUCCESS")
+        return True

--- a/django_project/project/tasks/store_data.py
+++ b/django_project/project/tasks/store_data.py
@@ -38,13 +38,12 @@ User = get_user_model()
     autoretry_for=(Exception,),
     retry_kwargs={"max_retries": 3, "countdown": 60},
 )
-def process_water_body(self, parameters, task_id, crawler_progress_id):    
+def process_water_body(self, parameters, task_id, crawler_progress_id):
     crawler_progress = CrawlProgress.objects.get(id=crawler_progress_id)
     task = AnalysisTask.objects.get(uuid=task_id)
     if task.status == Status.COMPLETED:
         self.update_state(state="SUCCESS")
         crawler_progress.increment_processed_data()
-
 
     # Extract water body
     success = run_analysis(**parameters)
@@ -69,7 +68,7 @@ def process_water_body(self, parameters, task_id, crawler_progress_id):
             "mask_path": output.file.path,
         })
         success = run_analysis(**parameters)
-        
+
         if not success:
             success &= False
     if not success:
@@ -162,13 +161,12 @@ def process_crawler(start_date, end_date, crawler_id):
                     crawler_progress.id,
                     task.uuid.hex
                 )
-                
+
         TaskLog.objects.create(
             content_object=crawler_progress,
             log=log_msg,
             level=logging.INFO,
         )
-        print(skip_task)
 
         if skip_task:
             TaskLog.objects.create(
@@ -177,13 +175,13 @@ def process_crawler(start_date, end_date, crawler_id):
                 level=logging.INFO,
             )
             return
-        
+
         crawler_progress.data_to_process += 1
         crawler_progress.save()
         new_params = deepcopy(parameters)
         new_params.update({
             "task_id": task.uuid.hex,
-        })        
+        })
         result = process_water_body.delay(
             new_params,
             task.uuid.hex,

--- a/django_project/project/tests/tasks/test_update_data.py
+++ b/django_project/project/tests/tasks/test_update_data.py
@@ -96,7 +96,6 @@ class TestUpdateData(APITestCase):
         self.assertEqual(mock_process_water_body.call_count, 3671)
         self.assertEqual(AnalysisTask.objects.all().count(), 3671)
         crawl_progress = CrawlProgress.objects.first()
-        print(crawl_progress.id)
         self.assertEqual(crawl_progress.data_to_process, 3671)
         self.assertEqual(crawl_progress.status, Status.RUNNING)
         


### PR DESCRIPTION
This is PR for #94 
This PR skips processing water body per catchment, and directly call `process_water_body` to prevent duplicate waterbody processing.