### PR TITLE
Fix AnalysisTask Status

### DIFF
--- a/django_project/project/api_views/analysis.py
+++ b/django_project/project/api_views/analysis.py
@@ -159,8 +159,8 @@ class AnalysisTaskStatusAPIView(APIView):
     def get(self, request, task_uuid):
         detail = request.GET.get('detail', 'false').lower() in ['true', '1']
         task = get_object_or_404(AnalysisTask, uuid=task_uuid)
+        serializer = AnalysisTaskStatusSerializer(task, context={'request': request})
         if detail:
-            serializer = AnalysisTaskStatusSerializer(task, context={'request': request})
             response = serializer.data
         else:
             response = {'status': serializer.data['status']}

--- a/django_project/project/api_views/analysis.py
+++ b/django_project/project/api_views/analysis.py
@@ -124,6 +124,7 @@ class WaterAnalysisAPIView(APIView):
 
         try:
             result = run_analysis_task.delay(**parameters)
+            task.refresh_from_db()
             task.celery_task_id = result.id
             task.save()
 
@@ -158,13 +159,11 @@ class AnalysisTaskStatusAPIView(APIView):
     def get(self, request, task_uuid):
         detail = request.GET.get('detail', 'false').lower() in ['true', '1']
         task = get_object_or_404(AnalysisTask, uuid=task_uuid)
-        result = AsyncResult(task.celery_task_id)
         if detail:
             serializer = AnalysisTaskStatusSerializer(task, context={'request': request})
             response = serializer.data
-            response['status'] = result.status
         else:
-            response = {'status': result.status}
+            response = {'status': serializer.data['status']}
         return Response(response, status=status.HTTP_200_OK)
 
 

--- a/django_project/project/tests/api_views/test_analysis.py
+++ b/django_project/project/tests/api_views/test_analysis.py
@@ -11,8 +11,8 @@ from django.conf import settings
 from django.test import override_settings
 from rest_framework.test import APITestCase, APIClient
 from rest_framework import status
-from core.factories import UserFactory  # Assuming this is your factory import
-from project.models.monitor import AnalysisTask
+from core.factories import UserFactory
+from project.models.monitor import AnalysisTask, Status
 from project.utils.calculations.analysis import Analysis
 
 
@@ -79,7 +79,7 @@ class WaterAnalysisAPIViewTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["task_name"], f"Water Analysis {self.user.username}")
         self.assertEqual(response.data["uuid"], str(task_id))
-        self.assertEqual(response.data["status"], "SUCCESS")
+        self.assertEqual(response.data["status"], Status.COMPLETED)
         self.assertEqual(
             response.data["parameters"],
             {

--- a/django_project/project/tests/test_awei_api.py
+++ b/django_project/project/tests/test_awei_api.py
@@ -83,7 +83,7 @@ class AWEIApiTestCase(APITestCase):
     @patch("project.utils.calculations.analysis.Client")
     @patch("project.utils.calculations.analysis.stac_load")
     @patch("project.api_views.water_extent.AsyncResult")
-    def test_aaaaa(self, mock_async_result, mock_stac_load, mock_client):
+    def test_trigger_water_extent(self, mock_async_result, mock_stac_load, mock_client):
         """Test if the water extent task is triggered successfully."""
         # Mock stac_load to return dummy xarray.Dataset with necessary bands
         mock_async_result.return_value.status = "SUCCESS"


### PR DESCRIPTION
Sometimes, there is discrepancy between AsyncResult status and AnalysisTaskStatus. Client reported that in their case, status from AsyncResult is pending while the AnalysisTaskStatus is done and the outputs are already created. 

Use status from AnalysisTaskStatus instead of AsyncResult